### PR TITLE
文章的表名写错了，应该为新的表名[cms_article]

### DIFF
--- a/src/main/java/com/github/niefy/modules/wx/entity/Article.java
+++ b/src/main/java/com/github/niefy/modules/wx/entity/Article.java
@@ -12,7 +12,7 @@ import java.util.Date;
  * 文章抽象：帮助中心文章、公告、资讯文章等分别存储到不同的表
  */
 @Data
-@TableName("article")
+@TableName("cms_article")
 public class Article implements Serializable {
     private static final long serialVersionUID = 1L;
     @TableId(type = IdType.AUTO)


### PR DESCRIPTION
文章的表名写错了，应该为新的表名[cms_article]