### PR TITLE
文章的表名写错了，应该为新的表名[cms_article]

### DIFF
--- a/src/main/resources/mapper/wx/ArticleMapper.xml
+++ b/src/main/resources/mapper/wx/ArticleMapper.xml
@@ -5,6 +5,6 @@
 
 
     <update id="addOpenCount">
-        UPDATE article SET open_count=open_count+1 WHERE id=#{id}
+        UPDATE cms_article SET open_count=open_count+1 WHERE id=#{id}
     </update>
 </mapper>


### PR DESCRIPTION
文章的表名写错了，应该为新的表名[cms_article]